### PR TITLE
Add a GitHub Action to refresh the README

### DIFF
--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -1,0 +1,31 @@
+---
+name: Update README
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 11 * * *'
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+    - name: Install dependencies
+      run: bundle install
+    - name: Update README
+      run: |-
+        bin/update_readme
+        cat README.md
+    - name: Commit and push if changed
+      run: |-
+        git diff
+        git config --global user.email "actions@users.noreply.github.com"
+        git config --global user.name "README Bot"
+        git add -A
+        git commit -m "Updated content" || exit 0
+        git push

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.bundle
+vendor

--- a/bin/update_readme
+++ b/bin/update_readme
@@ -1,5 +1,9 @@
 #!/usr/bin/env ruby
 
+require "bundler"
+
+Bundler.require
+
 $:.push File.expand_path("../lib", __dir__)
 
 require "pry"

--- a/lib/github_contributions.rb
+++ b/lib/github_contributions.rb
@@ -38,7 +38,6 @@ class GithubContributions
     {
       "User-Agent" => "Recent GitHub Contributions (#{username})",
       "Accept" => "application/vnd.github+json",
-      "Authorization" => "token #{ENV['GITHUB_TOKEN']}"
     }
   end
 end


### PR DESCRIPTION
This is almost verbatim stolen from @simonw's GitHub Action to do the same, just in Ruby.

Some additional changes:

* We need to load the bundle inside the script,
* We need to ignore some files which would otherwise be added by the GitHub Actions environment,
* We don't want to set an `Authorize` header, so that we're sure we'll only be able to access public information

https://simonwillison.net/2020/Jul/10/self-updating-profile-readme/